### PR TITLE
Allow picking branch to deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You'll need to provide some env to use the action.
 
 * **HOST**: The host the action will SSH to run the git push command. ie, `your.site.com`.
 * **PROJECT**: The project is Dokku project name.
+* **BRANCH**: Repository branch that should be used for deploy, `master` is set by default.
 
 ## License
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,5 +23,4 @@ ssh-keyscan -t rsa $HOST >> "$SSH_PATH/known_hosts"
 
 git checkout $DEPLOY_BRANCH
 
-GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \ 
-git push dokku@$HOST:$PROJECT $DEPLOY_BRANCH:master
+GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git push dokku@$HOST:$PROJECT $DEPLOY_BRANCH:master

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@
 set -e
 
 SSH_PATH="$HOME/.ssh"
+DEPLOY_BRANCH="${BRANCH-master}"
 
 mkdir -p "$SSH_PATH"
 touch "$SSH_PATH/known_hosts"
@@ -20,6 +21,7 @@ ssh-add "$SSH_PATH/deploy_key"
 
 ssh-keyscan -t rsa $HOST >> "$SSH_PATH/known_hosts"
 
-git checkout master
+git checkout $DEPLOY_BRANCH
 
-GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git push dokku@$HOST:$PROJECT master
+GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \ 
+git push dokku@$HOST:$PROJECT $DEPLOY_BRANCH:master


### PR DESCRIPTION
This will allow to pick branch that will be used for deploy. By default will use `master`, if no `$BRANCH` var is defined.