### PR TITLE
Create a FORCE_DEPLOY option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ You'll need to provide some env to use the action.
 - **BRANCH**: Repository branch that should be used for deploy, `master` is set by default.
 - **PORT**: Port of the sshd listen to, `22` is set by default.
 
-## Optional Environments
+### Optional Environments
 
 You can optionally provide the following:
 
 - **FORCE_DEPLOY**: Force push the project to dokku, e.g. `FORCE_DEPLOY=true`
+
 ## License
 
 The Dockerfile and associated scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ You'll need to provide some env to use the action.
 - **BRANCH**: Repository branch that should be used for deploy, `master` is set by default.
 - **PORT**: Port of the sshd listen to, `22` is set by default.
 
+## Optional Environments
+
+You can optionally provide the following:
+
+- **FORCE_DEPLOY**: Force push the project to dokku, e.g. `FORCE_DEPLOY=true`
 ## License
 
 The Dockerfile and associated scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,8 @@ set -e
 
 SSH_PATH="$HOME/.ssh"
 DEPLOY_BRANCH="${BRANCH-master}"
-[[ -z "${FORCE_DEPLOY}" ]] && FORCE='' || $([ "$FORCE_DEPLOY" == true ] && FORCE="--force" || FORCE="")
+
+FORCE=$([ "$FORCE_DEPLOY" == true ] && echo "--force" || echo "")
 
 mkdir -p "$SSH_PATH"
 touch "$SSH_PATH/known_hosts"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 
 SSH_PATH="$HOME/.ssh"
 DEPLOY_BRANCH="${BRANCH-master}"
+[[ -z "${FORCE_DEPLOY}" ]] && FORCE='' || $([ "$FORCE_DEPLOY" == true ] && FORCE="--force" || FORCE="")
 
 mkdir -p "$SSH_PATH"
 touch "$SSH_PATH/known_hosts"
@@ -25,4 +26,4 @@ git checkout $DEPLOY_BRANCH
 
 echo "The deploy is starting"
 
-GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p ${PORT-22}" git push dokku@$HOST:$PROJECT $DEPLOY_BRANCH:master
+GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p ${PORT-22}" git push dokku@$HOST:$PROJECT $DEPLOY_BRANCH:master $FORCE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 SSH_PATH="$HOME/.ssh"
 DEPLOY_BRANCH="${BRANCH-master}"
 
-FORCE=$([ "$FORCE_DEPLOY" == true ] && echo "--force" || echo "")
+FORCE=$([ "$FORCE_DEPLOY" = true ] && echo "--force" || echo "")
 
 mkdir -p "$SSH_PATH"
 touch "$SSH_PATH/known_hosts"


### PR DESCRIPTION
Sometimes when deploying to Dokku it can be useful to force push the project, this gives the option to do this by setting the `FORCE_DEPLOY` env to `true`