### PR TITLE
Provide identity file directly to SSH instead of going via the SSH agent (2/4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/tests/_run.sh

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You'll need to provide some env to use the action.
 You can optionally provide the following:
 
 - **FORCE_DEPLOY**: Force push the project to dokku, e.g. `FORCE_DEPLOY=true`
+- **HOST_KEY**: The results of running `ssh-keyscan -t rsa $HOST`. Use this if you want to check that the host you're deploying to is the right one (e.g. has the same keys).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ jobs:
       uses: vitalyliber/dokku-github-action@v4.0
       env:
         PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        PUBLIC_KEY: ${{ secrets.PUBLIC_KEY }}
         HOST: casply.com
         PROJECT: kawaii
 ```
@@ -37,7 +36,6 @@ jobs:
 You'll need to provide some secrets to use the action.
 
 - **PRIVATE_KEY**: Your SSH private key.
-- **PUBLIC_KEY**: Your SSH public key.
 
 ### Required Environments
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,22 +4,16 @@ set -e
 
 SSH_PATH="$HOME/.ssh"
 mkdir -p "$SSH_PATH"
+chmod 700 "$SSH_PATH"
 
 DEPLOY_BRANCH="${BRANCH-master}"
 FORCE=$([ "$FORCE_DEPLOY" = true ] && echo "--force" || echo "")
 
 echo "$PRIVATE_KEY" > "$SSH_PATH/deploy_key"
-echo "$PUBLIC_KEY" > "$SSH_PATH/deploy_key.pub"
-
-chmod 700 "$SSH_PATH"
 chmod 600 "$SSH_PATH/deploy_key"
-chmod 600 "$SSH_PATH/deploy_key.pub"
-
-eval $(ssh-agent)
-ssh-add "$SSH_PATH/deploy_key"
 
 
-GIT_SSH_COMMAND="ssh -p ${PORT-22}"
+GIT_SSH_COMMAND="ssh -p ${PORT-22} -i $SSH_PATH/deploy_key"
 
 
 if [ -n "$HOST_KEY" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,28 +3,34 @@
 set -e
 
 SSH_PATH="$HOME/.ssh"
-DEPLOY_BRANCH="${BRANCH-master}"
-
-FORCE=$([ "$FORCE_DEPLOY" = true ] && echo "--force" || echo "")
-
 mkdir -p "$SSH_PATH"
-touch "$SSH_PATH/known_hosts"
+
+DEPLOY_BRANCH="${BRANCH-master}"
+FORCE=$([ "$FORCE_DEPLOY" = true ] && echo "--force" || echo "")
 
 echo "$PRIVATE_KEY" > "$SSH_PATH/deploy_key"
 echo "$PUBLIC_KEY" > "$SSH_PATH/deploy_key.pub"
 
 chmod 700 "$SSH_PATH"
-chmod 600 "$SSH_PATH/known_hosts"
 chmod 600 "$SSH_PATH/deploy_key"
 chmod 600 "$SSH_PATH/deploy_key.pub"
 
 eval $(ssh-agent)
 ssh-add "$SSH_PATH/deploy_key"
 
-ssh-keyscan -t rsa $HOST >> "$SSH_PATH/known_hosts"
+
+GIT_SSH_COMMAND="ssh -p ${PORT-22}"
+
+
+if [ -n "$HOST_KEY" ]; then
+    echo "$HOST_KEY" >> "$SSH_PATH/known_hosts"
+    chmod 600 "$SSH_PATH/known_hosts"
+else
+    GIT_SSH_COMMAND="$GIT_SSH_COMMAND -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+fi
 
 git checkout $DEPLOY_BRANCH
 
 echo "The deploy is starting"
 
-GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p ${PORT-22}" git push dokku@$HOST:$PROJECT $DEPLOY_BRANCH:master $FORCE
+GIT_SSH_COMMAND="$GIT_SSH_COMMAND" git push dokku@$HOST:$PROJECT $DEPLOY_BRANCH:master $FORCE

--- a/tests/host_key_fails.sh
+++ b/tests/host_key_fails.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+docker run \
+    --env "BRANCH=$BRANCH" \
+    --env "PRIVATE_KEY=$PRIVATE_KEY" \
+    --env "PUBLIC_KEY=$PUBLIC_KEY" \
+    --env "HOST=$HOST" \
+    --env "HOST_KEY=123" \
+    --env "PROJECT=$PROJECT" \
+    --workdir "/repo" \
+    --volume "$LOCAL_REPO:/repo" \
+    dokku-github-action

--- a/tests/host_key_skipped.sh
+++ b/tests/host_key_skipped.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+docker run \
+    --env "BRANCH=$BRANCH" \
+    --env "PRIVATE_KEY=$PRIVATE_KEY" \
+    --env "PUBLIC_KEY=$PUBLIC_KEY" \
+    --env "HOST=$HOST" \
+    --env "PROJECT=$PROJECT" \
+    --workdir "/repo" \
+    --volume "$LOCAL_REPO:/repo" \
+    dokku-github-action

--- a/tests/host_key_works.sh
+++ b/tests/host_key_works.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+docker run \
+    --env "BRANCH=$BRANCH" \
+    --env "PRIVATE_KEY=$PRIVATE_KEY" \
+    --env "PUBLIC_KEY=$PUBLIC_KEY" \
+    --env "HOST=$HOST" \
+    --env "HOST_KEY=$HOST_KEY" \
+    --env "PROJECT=$PROJECT" \
+    --workdir "/repo" \
+    --volume "$LOCAL_REPO:/repo" \
+    dokku-github-action

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Sets up the environment for running the tests, then runs them.
+# Use this as a way to test that the action works in lots of different scenarios
+#
+# Make a copy of this file called _run.sh and fill in the env vars.
+# _run.sh is gitignored so you won't accidently commit your SSH keys.
+set -eu
+
+docker build --tag dokku-github-action .
+
+# Set these as you would expect to set them when using the action
+export HOST=
+export PROJECT=
+export BRANCH=
+
+
+# An absolute path to a git repo on your local machine that can be pushed to dokku
+export LOCAL_REPO=
+# An absolute path to the private key that can be used to deploy this project
+PRIVATE_KEY=
+PRIVATE_KEY=$(cat $PRIVATE_KEY)
+export PRIVATE_KEY
+# An absolute path to the public key for the above private key
+PUBLIC_KEY=
+PUBLIC_KEY=$(cat $PUBLIC_KEY)
+export PUBLIC_KEY
+
+# This grabs the current host key for HOST
+HOST_KEY=$(ssh-keyscan -t rsa "$HOST")
+export HOST_KEY
+
+./tests/host_key_fails.sh
+./tests/host_key_skipped.sh
+./tests/host_key_works.sh


### PR DESCRIPTION
This one removes the need to boot up the SSH agent. It just gives the private key directly to the SSH command via the `-i` arg.

This PR also removes the public key env var. So that should fix #5.

I've also added more testing things so that I could run the action on my local machine.